### PR TITLE
Make 'ferto' aware of different notifier backends in 'downloader'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,49 @@ client = Ferto::Client.new(
 
 ### Downloading a file
 
-```ruby
-client.download(aggr_id: 'bucket1',
-                aggr_limit: '3',
-                url: 'http://example.com/',
-                mime_type: 'text/html',
-                callback_url: 'http://myservice.com/downloader_callback',
-                extra: { some_extra_info: 'info' })
+[downloader](https://github.com/skroutz/downloader) supports multiple
+notification backends for the download results. Currently, there are two
+supported options: an HTTP and a Kafka backend. Let's see how to issue a
+download request in each case:
 
+#### HTTP-based notification backend
+
+```ruby
+dl_resp = client.download(aggr_id: 'bucket1',
+                          aggr_limit: 3,
+                          url: 'http://example.com/',
+                          mime_type: 'text/html',
+                          callback_type: 'http',
+                          callback_dst: 'http://myservice.com/downloader_callback',
+                          extra: { some_extra_info: 'info' })
 ```
 
-For the semantics of those options refer to [downloader's documentation](https://github.com/skroutz/downloader#endpoints)
+In order for a service to consume downloader's result, it *must* accept the HTTP
+callback in the endpoint denoted by `callback_dst`.
 
+#### Kafka-based notification backend
 
-In order for a service to consume downloader's result, it must accept the HTTP
-callback in some endpoint passed in `callback_url`.
+```ruby
+dl_resp = client.download(aggr_id: 'bucket1',
+                          aggr_limit: 3,
+                          url: 'http://example.com/',
+                          mime_type: 'text/html',
+                          callback_type: 'kafka',
+                          callback_dst: 'my-kafka-topic',
+                          extra: { some_extra_info: 'info' })
+```
 
-To consume the callback, e.g. from inside a Rails controller:
+To consume the downloader's result, you can use your favorite Kafka library and
+consume the callback message from `my-kafka-topic` (passed in `callback_dst`).
+
+If the connection with the `downloader` API was successful, the aforementioned
+`dl_resp` is a
+[`Ferto::Response`](https://github.com/skroutz/ferto/blob/master/lib/ferto/response.rb#L2)
+object. If the client failed to connect, a
+[`Ferto::ConnectionError`](https://github.com/skroutz/ferto/blob/master/lib/ferto.rb#L18)
+exception is raised.
+
+To handle the actual callback message, e.g. from inside a Rails controller:
 
 ```ruby
 class DownloaderController < ApplicationConroller
@@ -71,6 +97,12 @@ class DownloaderController < ApplicationConroller
 end
 ```
 
+> For the detailed semantics of each option and the format of the callback
+> payload, please, refer to the official downloader's documentation ([download
+> parameters](https://github.com/skroutz/downloader#endpoints), [callback
+> payload](https://github.com/skroutz/downloader/tree/kafka-backend#usage)).
+
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/skroutz/ferto.
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/skroutz/ferto.

--- a/lib/ferto/client.rb
+++ b/lib/ferto/client.rb
@@ -1,3 +1,6 @@
+require "curl"
+require "json"
+
 module Ferto
   class Client
     # @return [String]

--- a/lib/ferto/version.rb
+++ b/lib/ferto/version.rb
@@ -1,3 +1,3 @@
 module Ferto
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/ferto/client_spec.rb
+++ b/spec/ferto/client_spec.rb
@@ -36,7 +36,8 @@ describe Ferto::Client do
         aggr_id: 'bucket1',
         aggr_limit: 3,
         url: 'https://foo.bar/a.jpg',
-        callback_url: 'http://example.com/downloads/myfile',
+        callback_type: 'my-callback-mechanism',
+        callback_dst: 'http://example.com/downloads/myfile',
         extra: { product: 1234, actor: 'actor1' }
       }
     end
@@ -63,6 +64,24 @@ describe Ferto::Client do
       expect(subject.job_id).to eq job_id
     end
 
+    context 'when the HTTP notifier backend is selected via callback_url' do
+      let(:params) do
+        {
+          aggr_id: 'bucket1',
+          aggr_limit: 3,
+          url: 'https://foo.bar/a.jpg',
+          callback_url: 'http://example.com/downloads/myfile',
+          extra: { product: 1234, actor: 'actor1' }
+        }
+      end
+
+      it 'returns ok' do
+        expect(subject).to be_a Ferto::Response
+        expect(subject.response_code).to eq 201
+        expect(subject.job_id).to eq job_id
+      end
+    end
+
     context "when connection error" do
       before do
         stub_request(:post, downloader_url).
@@ -79,7 +98,9 @@ describe Ferto::Client do
         {
           aggr_id: 'bucket1',
           aggr_limit: 3,
-          url: 'https://foo.bar/a.jpg',
+          # missing 'url' param
+          callback_type: 'my-callback-mechanism',
+          callback_dst: 'http://example.com/downloads/myfile',
           extra: { product: 1234, actor: 'actor1' }
         }
       end


### PR DESCRIPTION
These commits add support to select one of the available downloader notification backends via 'ferto'. The user should use the client with the intended `callback_type` (to define one of the supported notifier backends) and `callback_dst` (to define the callback endpoint) instead of the `callback_url` option which is considered obsolete.

This work is related to the work done in https://github.com/skroutz/downloader/pull/5/.