### PR TITLE
Introduce Ferto::ResponseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ## master (unreleased)
 
+## 0.0.5 (2019-05-16)
 
+### Added
 
+- [BREAKING] `Ferto::ResponseError` exception raising when 40X or 50X response is returned [[#9](https://github.com/skroutz/ferto/pull/9)]
 
 ## 0.0.4 (2019-04-18)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ If the connection with the `downloader` API was successful, the aforementioned
 object. If the client failed to connect, a
 [`Ferto::ConnectionError`](https://github.com/skroutz/ferto/blob/master/lib/ferto.rb#L18)
 exception is raised.
+Also if the download call, results to a response with code
+either `40X` or `50X` then a [`Ferto::ResponseError`](https://github.com/skroutz/ferto/blob/master/lib/ferto.rb#L21)
+is raised with the response object encapsulated in the raised exception in order 
+to be further handled by the end user.
 
 To handle the actual callback message, e.g. from inside a Rails controller:
 

--- a/lib/ferto.rb
+++ b/lib/ferto.rb
@@ -16,4 +16,25 @@ module Ferto
   }.freeze
 
   class ConnectionError < StandardError; end
+  
+  # A custom error class for 40X and 50X responses
+  class ResponseError < StandardError
+    
+    # Initialize a Ferto::ResponseError
+    #
+    # @param [String] err A string describing the error occured
+    # @param [Curl::Easy | nil] response a Curl::Easy object
+    #   that represents the response returned by the download method.
+    #   Default: nil
+    def initialize(err, response=nil)
+      super(err)
+      @response = response
+    end
+
+    # response is set, during the download in case of
+    # 40X or 50X responses are returned, so that it
+    # can be used in case of debugging but it is also 
+    # included for reasons of completeness.
+    attr_reader :response
+  end
 end

--- a/lib/ferto/version.rb
+++ b/lib/ferto/version.rb
@@ -1,3 +1,3 @@
 module Ferto
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/spec/ferto/client_spec.rb
+++ b/spec/ferto/client_spec.rb
@@ -93,6 +93,22 @@ describe Ferto::Client do
       end
     end
 
+    context "when a 40X or 50X response code is returned" do
+      before do
+        stub_request(:post, downloader_url).
+          to_return(status: 500,
+                    body: "Internal Server Error",
+                    headers: { 'Content-Type' => 'Application/json' })
+      end
+
+      it "raises Ferto::ResponseError" do
+        error_msg = ("An error occured during the download call. "  \
+          "Received a 500 response code and body " \
+          "Internal Server Error")
+        expect { subject }.to raise_error(Ferto::ResponseError, error_msg)
+      end
+    end
+
     context 'when a required param is missing' do
       let(:params) do
         {


### PR DESCRIPTION
This pull request enhances the error handing mechanism considering the `download` method of the `Ferto::Client` class. More specifically it introduces a `Ferto::ResponseError` in case 40X or 50X responses are returned.

Error handling is a pretty important subject and for that reason we tried to handle erroneous response codes and curl exceptions using `Ferto` exception classes so the user can catch them
and handle them appropriately in a unified manner.