### PR TITLE
Allow AWS S3 bucket as filestorage solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 - Support for setting request headers in download requests [[#10](https://github.com/skroutz/ferto/pull/10)]
 
+## 0.0.7 (2022-07-21)
+
+### Added
+
+- Support for setting AWS S3 bucket as filestorage solution [[#11](https://github.com/skroutz/ferto/pull/11)]
+
 ## 0.0.5 (2019-05-16)
 
 ### Added

--- a/lib/ferto/client.rb
+++ b/lib/ferto/client.rb
@@ -91,7 +91,8 @@ module Ferto
                  aggr_proxy: nil, download_timeout: nil, user_agent: nil,
                  callback_url: "", callback_dst: "",
                  callback_type: "", mime_type: "", extra: {},
-                 request_headers: {})
+                 request_headers: {},
+                 s3_bucket: nil, s3_region: nil)
       uri = URI::HTTP.build(
         scheme: scheme, host: host, port: port, path: path
       )
@@ -99,7 +100,8 @@ module Ferto
         aggr_id, aggr_limit, url,
         callback_url, callback_type, callback_dst,
         aggr_proxy, download_timeout, user_agent,
-        mime_type, extra, request_headers
+        mime_type, extra, request_headers,
+        s3_bucket, s3_region
       )
       # Curl.post reuses the same handler
       begin
@@ -134,12 +136,24 @@ module Ferto
 
     def build_body(aggr_id, aggr_limit, url, callback_url, callback_type,
                    callback_dst, aggr_proxy, download_timeout, user_agent,
-                   mime_type, extra, request_headers)
+                   mime_type, extra, request_headers,
+                   s3_bucket, s3_region)
       body = {
         aggr_id: aggr_id,
         aggr_limit: aggr_limit,
         url: url
       }
+
+      if s3_bucket && s3_region
+        body[:s3_bucket] = s3_bucket
+        body[:s3_region] = s3_region
+      end
+
+      if !s3_bucket && s3_region
+        raise ArgumentError, "s3_region provided without an s3_bucket"
+      elsif !s3_region && s3_bucket
+        raise ArgumentError, "s3_bucket provided without an s3_region"
+      end
 
       if callback_url.empty?
         body[:callback_type] = callback_type

--- a/lib/ferto/version.rb
+++ b/lib/ferto/version.rb
@@ -1,3 +1,3 @@
 module Ferto
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
Downloader[1], since [2], can support AWS S3 buckets as a filestorage
solution. With these changes, ferto is updated to accept and forward
`s3_bucket` and `s3_region` options to downloader, providing the
option to ferto's clients to choose S3 buckets as their storage endpoint.

If these options are used, callback_url, callback_type and callback_dst
are optional to be set from user.

[1] https://github.com/skroutz/downloader
[2] https://github.com/skroutz/downloader/commit/958da5dd0be8f95b31a300a6086303cb364f109d

Ref T113990