### PR TITLE
Error callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ## master (unreleased)
 
+## 0.0.9 (2022-11-14)
+
+### Added
+
+- Support for different callbacks when a job fails [[#13](https://github.com/skroutz/ferto/pull/13)]
+
 ## 0.0.8 (2022-08-16)
 
 ### Added

--- a/lib/ferto/client.rb
+++ b/lib/ferto/client.rb
@@ -50,6 +50,8 @@ module Ferto
     # @param url           [String] the resource to be downloaded
     # @param callback_type [String]
     # @param callback_dst  [String] the callback destination
+    # @param callback_error_type [String]
+    # @param callback_error_dst  [String] the callback destination in case the job fails
     # @param mime_type     [String] (default: "") accepted MIME types for the
     #   resource
     # @param aggr_id       [String] aggregation identifier
@@ -91,8 +93,9 @@ module Ferto
     # @see https://github.com/skroutz/downloader/#post-download
     def download(aggr_id:, aggr_limit: @aggr_limit, url:,
                  aggr_proxy: nil, download_timeout: nil, user_agent: nil,
-                 callback_url: "", callback_dst: "",
-                 callback_type: "", mime_type: "", extra: {},
+                 callback_url: "", callback_dst: "", callback_type: "",
+                 callback_error_type: "", callback_error_dst: "",
+                 mime_type: "", extra: {},
                  request_headers: {},
                  s3_bucket: nil, s3_region: nil, subpath: nil)
       uri = URI::HTTP.build(
@@ -101,6 +104,7 @@ module Ferto
       body = build_body(
         aggr_id, aggr_limit, url,
         callback_url, callback_type, callback_dst,
+        callback_error_type, callback_error_dst,
         aggr_proxy, download_timeout, user_agent,
         mime_type, extra, request_headers,
         s3_bucket, s3_region, subpath
@@ -137,7 +141,8 @@ module Ferto
     end
 
     def build_body(aggr_id, aggr_limit, url, callback_url, callback_type,
-                   callback_dst, aggr_proxy, download_timeout, user_agent,
+                   callback_dst, callback_error_type, callback_error_dst,
+                   aggr_proxy, download_timeout, user_agent,
                    mime_type, extra, request_headers,
                    s3_bucket, s3_region, subpath)
       body = {
@@ -163,6 +168,9 @@ module Ferto
       else
         body[:callback_url] = callback_url
       end
+
+      body[:callback_error_type] = callback_error_type unless callback_error_type.to_s.empty?
+      body[:callback_error_dst] = callback_error_dst unless callback_error_dst.to_s.empty?
 
       if !mime_type.empty?
         body[:mime_type] = mime_type

--- a/lib/ferto/version.rb
+++ b/lib/ferto/version.rb
@@ -1,3 +1,3 @@
 module Ferto
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end


### PR DESCRIPTION
Error callbacks are optional and can be used when user wants to get notifications on a separate notification channel for a failed job.