### PR TITLE
Curl handle reuse fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ## master (unreleased)
 
+## 0.1.1 (2026-07-11)
+
+- Manage a per-thread `Curl::Easy` handle in `Client#download` instead of
+  relying on `Curl.post`, whose per-thread handle cache was removed in curb
+  1.3.6. Restores keep-alive connection reuse towards the downloader and
+  prevents open-connection pile-up in long-lived workers.
+  Note: like every setup before curb 1.3.6, the long-lived cached handle is
+  only safe under GC compaction with curb >= 1.3.7 (or a build carrying the
+  `curl_easy_mark` pin fix). The gemspec intentionally leaves curb
+  unconstrained — the consuming app owns the curb version.
+- [BREAKING] `Ferto::Response` is now a plain snapshot object instead of a
+  `SimpleDelegator` around the `Curl::Easy` handle: `response_code` and `body`
+  (aliased as `body_str`) are captured when the response is built, so a
+  response held across `download` calls keeps its own data instead of
+  exposing the reused handle's next request. Other `Curl::Easy` methods are
+  no longer forwarded.
+- [BREAKING] `Ferto::ResponseError#response` now returns a `Ferto::Response`
+  snapshot instead of the live `Curl::Easy` handle, which a subsequent
+  `download` on the same thread would have reset.
 - Add compatibility for Ruby 3.4 and 3.5
 
 ## 0.1.0 (2023-06-16)

--- a/lib/ferto.rb
+++ b/lib/ferto.rb
@@ -23,8 +23,8 @@ module Ferto
     # Initialize a Ferto::ResponseError
     #
     # @param [String] err A string describing the error occured
-    # @param [Curl::Easy | nil] response a Curl::Easy object
-    #   that represents the response returned by the download method.
+    # @param [Ferto::Response | nil] response a snapshot of the
+    #   response returned by the download method.
     #   Default: nil
     def initialize(err, response=nil)
       super(err)

--- a/lib/ferto/client.rb
+++ b/lib/ferto/client.rb
@@ -109,26 +109,30 @@ module Ferto
         mime_type, extra, request_headers,
         s3_bucket, s3_region, subpath
       )
-      # Curl.post reuses the same handler
       begin
-        res = Curl.post(uri.to_s, body.to_json) do |handle|
-          handle.headers = build_header(aggr_id)
-          handle.connect_timeout = connect_timeout
-          handle.timeout = timeout
-        end
+        # Inlines what the Curl.post shortcut did internally (url, post_body,
+        # perform) plus the options previously passed in its block, on a
+        # handle we manage ourselves.
+        handle = curl_handle
+        handle.url = uri.to_s
+        handle.headers = build_header(aggr_id)
+        handle.connect_timeout = connect_timeout
+        handle.timeout = timeout
+        handle.post_body = body.to_json
+        handle.http(:POST)
 
-        case res.response_code
+        case handle.response_code
         when 400..599
           error_msg = ("An error occured during the download call. "  \
-            "Received a #{res.response_code} response code and body " \
-            "#{res.body_str}")
-          raise Ferto::ResponseError.new(error_msg, res)
+            "Received a #{handle.response_code} response code and body " \
+            "#{handle.body_str}")
+          raise Ferto::ResponseError.new(error_msg, handle)
         end
       rescue Curl::Err::ConnectionFailedError => e
         raise Ferto::ConnectionError.new(e)
       end
 
-      Ferto::Response.new res
+      Ferto::Response.new handle
     end
 
     private
@@ -138,6 +142,17 @@ module Ferto
         'Content-Type': 'application/json',
         'X-Aggr': aggr_id.to_s
       }
+    end
+
+    # One handle per thread: curl_easy_reset keeps live connections, so the
+    # keep-alive connection to the downloader is reused across calls.
+    # Deliberately fiber-local (Thread.current[]): sharing a handle across
+    # fibers could let two fibers of one thread enter the same handle
+    # mid-transfer under a fiber scheduler; less reuse beats corruption.
+    def curl_handle
+      handle = Thread.current[:ferto_curl] ||= Curl::Easy.new
+      handle.reset
+      handle
     end
 
     def build_body(aggr_id, aggr_limit, url, callback_url, callback_type,

--- a/lib/ferto/client.rb
+++ b/lib/ferto/client.rb
@@ -121,18 +121,20 @@ module Ferto
         handle.post_body = body.to_json
         handle.http(:POST)
 
-        case handle.response_code
+        response = Ferto::Response.new(handle)
+
+        case response.response_code
         when 400..599
           error_msg = ("An error occured during the download call. "  \
-            "Received a #{handle.response_code} response code and body " \
-            "#{handle.body_str}")
-          raise Ferto::ResponseError.new(error_msg, handle)
+            "Received a #{response.response_code} response code and body " \
+            "#{response.body}")
+          raise Ferto::ResponseError.new(error_msg, response)
         end
       rescue Curl::Err::ConnectionFailedError => e
         raise Ferto::ConnectionError.new(e)
       end
 
-      Ferto::Response.new handle
+      response
     end
 
     private

--- a/lib/ferto/response.rb
+++ b/lib/ferto/response.rb
@@ -1,5 +1,17 @@
 module Ferto
-  class Response < SimpleDelegator
+  # A point-in-time snapshot of a download response. The underlying
+  # Curl::Easy handle is reused by the thread's next download, so every
+  # field is captured eagerly here and the handle is not retained.
+  class Response
+    attr_reader :response_code, :body
+
+    alias body_str body
+
+    def initialize(handle)
+      @response_code = handle.response_code
+      @body = handle.body
+    end
+
     def job_id
       @job_id ||= body.nil? ? nil : JSON.parse(body)['id']
     end

--- a/lib/ferto/version.rb
+++ b/lib/ferto/version.rb
@@ -1,3 +1,3 @@
 module Ferto
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/ferto/client_spec.rb
+++ b/spec/ferto/client_spec.rb
@@ -92,6 +92,47 @@ describe Ferto::Client do
       expect(subject.job_id).to eq job_id
     end
 
+    describe 'curl handle reuse' do
+      before { Thread.current[:ferto_curl] = nil }
+
+      it 'reuses the same Curl::Easy handle across calls on the same thread' do
+        downloader.download(**params)
+        handle = Thread.current[:ferto_curl]
+        expect(handle).to be_a(Curl::Easy)
+
+        downloader.download(**params)
+        expect(Thread.current[:ferto_curl]).to be(handle)
+      end
+
+      # Deliberate: a shared handle could be entered by two fibers of the
+      # same thread mid-transfer under a fiber scheduler.
+      it 'uses a separate handle per fiber' do
+        downloader.download(**params)
+        handle = Thread.current[:ferto_curl]
+
+        fiber_handle = Fiber.new do
+          downloader.download(**params)
+          Thread.current[:ferto_curl]
+        end.resume
+
+        expect(fiber_handle).to be_a(Curl::Easy)
+        expect(fiber_handle).not_to be(handle)
+      end
+
+      it 'uses a separate handle per thread' do
+        downloader.download(**params)
+        main_handle = Thread.current[:ferto_curl]
+
+        other_handle = Thread.new do
+          downloader.download(**params)
+          Thread.current[:ferto_curl]
+        end.value
+
+        expect(other_handle).to be_a(Curl::Easy)
+        expect(other_handle).not_to be(main_handle)
+      end
+    end
+
     context 'when the HTTP notifier backend is selected via callback_url' do
       let(:params) do
         {

--- a/spec/ferto/client_spec.rb
+++ b/spec/ferto/client_spec.rb
@@ -119,6 +119,19 @@ describe Ferto::Client do
         expect(fiber_handle).not_to be(handle)
       end
 
+      it 'keeps response data after a subsequent download reuses the handle' do
+        first = downloader.download(**params)
+
+        stub_request(:post, downloader_url).
+          to_return(status: 201,
+                    body: { 'id' => 'other456' }.to_json,
+                    headers: { 'Content-Type' => 'Application/json' })
+        downloader.download(**params)
+
+        expect(first.response_code).to eq 201
+        expect(first.job_id).to eq job_id
+      end
+
       it 'uses a separate handle per thread' do
         downloader.download(**params)
         main_handle = Thread.current[:ferto_curl]
@@ -175,6 +188,25 @@ describe Ferto::Client do
           "Received a 500 response code and body " \
           "Internal Server Error")
         expect { subject }.to raise_error(Ferto::ResponseError, error_msg)
+      end
+
+      it "keeps the error response intact after a subsequent download" do
+        error = nil
+        begin
+          subject
+        rescue Ferto::ResponseError => e
+          error = e
+        end
+
+        stub_request(:post, downloader_url).
+          to_return(status: 201,
+                    body: { 'id' => 'other456' }.to_json,
+                    headers: { 'Content-Type' => 'Application/json' })
+        downloader.download(**params)
+
+        expect(error.response).to be_a(Ferto::Response)
+        expect(error.response.response_code).to eq 500
+        expect(error.response.body).to eq "Internal Server Error"
       end
     end
 


### PR DESCRIPTION
Restore keep-alive connection reuse in Client#download

Client#download used Curl.post, which relied on curb's internal per-thread handle cache. That cache was removed in curb 1.3.6, so every download now opens a fresh connection — losing keep-alive reuse towards the downloader and piling up open connections in long-lived workers.

This branch manages a per-thread Curl::Easy handle ourselves, inlining what Curl.post did internally (set url, post_body, perform). The handle is reset between calls, which keeps live connections open, and is stored in Thread.current[:ferto_curl] — deliberately fiber-local, since a shared handle could be entered mid-transfer by two fibers of the same thread under a fiber scheduler.

Because the handle is now reused, Ferto::Response can no longer delegate to it. It becomes a plain eager snapshot