### PR TITLE
Bump github action versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,11 +16,13 @@ jobs:
         ruby-version: ['2.7', '3.2', '3.4', '3.5']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install dependencies
-        run: sudo apt install -y libcurl4-openssl-dev
+        run: |
+          sudo apt update
+          sudo apt install -y libcurl4-openssl-dev
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies


### PR DESCRIPTION
Older versions were depending on Node.js 20 which is no longer supported by GitHub.

Also make sure we're using fresh package lists when trying to retrieve
libcurl4-openssl-dev